### PR TITLE
Confusing test and validation concepts

### DIFF
--- a/tables/automl/notebooks/purchase_prediction/purchase_prediction.ipynb
+++ b/tables/automl/notebooks/purchase_prediction/purchase_prediction.ipynb
@@ -1209,7 +1209,7 @@
    "source": [
     "####**Train a model**\n",
     "\n",
-    "To create the datasets for training, testing and validation, we first had to consider what kind of data we were dealing with. The data we had keeps track of all customer sessions with the Google Merchandise store over a year. AutoML tables does its own training and testing, and delivers a quite nice UI to view the results in. For the training and testing dataset then, we simply used the over sampled, balanced dataset created by the transformations described above. But we first partitioned the dataset to include the first 9 months in one table and the last 3 in another. This allowed us to train and test with an entirely different dataset that what we used to validate.\n",
+    "To create the datasets for training, validation and testing, we first had to consider what kind of data we were dealing with. The data we had keeps track of all customer sessions with the Google Merchandise store over a year. AutoML tables does its own training and testing, and delivers a quite nice UI to view the results in. For the training and validation dataset then, we simply used the over sampled, balanced dataset created by the transformations described above. But we first partitioned the dataset to include the first 9 months in one table and the last 3 in another. This allowed us to train and validate with an entirely different dataset that what we used to test.\n",
     "\n",
     "Moreover, we held off on oversampling for the validation dataset, to not bias the data that we would ultimately use to judge the success of our model.\n",
     "\n",


### PR DESCRIPTION
According to GCP documentation (https://cloud.google.com/automl-tables/docs/prepare#ml-use) the split between train, validation and test is not properly explained in this example. Train and validation are the datasets that AutoML uses for training trial models and when a model is chosen then test dataset is shown to the model.